### PR TITLE
[#2] Install "libsndfile" package to be able to use the "sndfile" library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ RUN mkdir -p /lib/demucs
 
 WORKDIR /lib/demucs
 
-RUN git clone https://github.com/facebookresearch/demucs /lib/demucs
+RUN git clone -b master --single-branch https://github.com/facebookresearch/demucs /lib/demucs
 
 RUN conda env update -f environment-cpu.yml
 RUN conda init bash
 RUN echo "conda activate demucs" >> ~/.bashrc
+RUN apt install -y libsndfile1
 
 VOLUME /data/input
 VOLUME /data/output


### PR DESCRIPTION
This PR fixes  #2 . It seems there're some changes in the [Facebook Demucs library](https://github.com/facebookresearch/demucs) that need the `libsndfile` package to run.

@adefossez , could you check if this change is ok? I've tried to use the conda package manager adding the following line: 

```dockerfile
RUN conda install -c conda-forge libsndfile
```

just after the `RUN conda env update -f environment-cpu.yml` and it seems that it's not detected.

So the solution I've found is using `apt install`.