### PR TITLE
Adding support for Demucs V2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3:2020.11
+FROM python:3.8
 
 USER root
 
@@ -12,9 +12,9 @@ WORKDIR /lib/demucs
 
 RUN git clone https://github.com/facebookresearch/demucs /lib/demucs
 
-RUN conda env update -f environment-cpu.yml
-RUN conda init bash
-RUN echo "conda activate demucs" >> ~/.bashrc
+RUN python3 -m pip install -e .
+RUN python3 -m demucs.separate -d cpu test.mp3 # Trigger model download
+RUN rm -r separated  # cleanup
 
 VOLUME /data/input
 VOLUME /data/output

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /lib/demucs
 
 WORKDIR /lib/demucs
 
-RUN git clone https://github.com/facebookresearch/demucs /lib/demucs
+RUN git clone -b master --single-branch https://github.com/facebookresearch/demucs /lib/demucs
 
 RUN python3 -m pip install -e .
 RUN python3 -m demucs.separate -d cpu test.mp3 # Trigger model download

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run: build ## Build & Run the demucs spliting the tracks placed in the input fol
 		-v $(current-dir)output:/data/output \
 		-v $(current-dir)models:/data/models \
 		facebook/demucs:latest \
-		"python3 -m demucs.separate --dl -n demucs -d cpu --out /data/output --models /data/models \
+		"python3 -m demucs.separate --out /data/output --models /data/models \
 		/data/input/$(track)"
 .PHONY:
 build: ## Build docker image with all needed to run the facebook demucs ML code


### PR DESCRIPTION
Remove flags not longer supported (i.e. `--dl` which is now implied).

Use `demucs_quantized` model (only 150 MB for the same performance).

Trigger model download during image build, as location for pretrained models is no longer stored under the folder passed to `--models`, but inside PyTorch Hub cache.

Remove dependency on Anaconda image, as now only Python3 should be sufficient.