### PR TITLE
Demucs V3 Compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN rm -r separated  # cleanup
 
 VOLUME /data/input
 VOLUME /data/output
-VOLUME /data/models
 
 ENTRYPOINT ["/bin/bash", "--login", "-c"]
 

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ run: build ## Build & Run the demucs spliting the tracks placed in the input fol
 		--name=demucs \
 		-v $(current-dir)input:/data/input \
 		-v $(current-dir)output:/data/output \
-		-v $(current-dir)models:/data/models \
 		facebook/demucs:latest \
-		"python3 -m demucs.separate --out /data/output --models /data/models \
+		"python3 -m demucs.separate --out /data/output \
 		/data/input/$(track)"
 .PHONY:
 build: ## Build docker image with all needed to run the facebook demucs ML code


### PR DESCRIPTION
A few small changes that allowed compatibility for the new model:
 - remove --models flag from separate command (it does not exist in v3)
 - remove /data/models Docker volume

There may be some more elegant way to just add the models to the /data/models volume as well, but this gets the model up and running for those wanting to try v3. 🙂