### PR TITLE
[#7] Fix Demucs execution to make it compatible with V3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8
 
 USER root
+ENV TORCH_HOME=/data/models
 
 # Install Git
 RUN apt install git

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ run: build ## Build & Run the demucs spliting the tracks placed in the input fol
 		-v $(current-dir)input:/data/input \
 		-v $(current-dir)output:/data/output \
 		-v $(current-dir)models:/data/models \
-		-e TORCH_HOME=/data/models \
 		facebook/demucs:latest \
 		"python3 -m demucs.separate --out /data/output \
 		/data/input/$(track)"

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ run: build ## Build & Run the demucs spliting the tracks placed in the input fol
 		-v $(current-dir)input:/data/input \
 		-v $(current-dir)output:/data/output \
 		-v $(current-dir)models:/data/models \
+		-e TORCH_HOME=/data/models \
 		facebook/demucs:latest \
-		"python3 -m demucs.separate --out /data/output --models /data/models \
+		"python3 -m demucs.separate --out /data/output \
 		/data/input/$(track)"
 .PHONY:
 build: ## Build docker image with all needed to run the facebook demucs ML code


### PR DESCRIPTION
Set `TORCH_HOME` as docker env in the Makefile

```Makefile
docker run --rm -i \
		--name=demucs \
		-v $(current-dir)input:/data/input \
		-v $(current-dir)output:/data/output \
		-v $(current-dir)models:/data/models \
		-e TORCH_HOME=/data/models \
		facebook/demucs:latest \
		"python3 -m demucs.separate --out /data/output \
		/data/input/$(track)"
```