### PR TITLE
Use demucs in container with GPU instead of CPU 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
-FROM python:3.8
+FROM nvidia/cuda:11.8.0-base-ubuntu22.04
 
 USER root
 ENV TORCH_HOME=/data/models
 
+# Installing FFMpeg might have a prompt, avoid it with this
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Basic set
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl
+RUN apt-get -y install python3
+RUN apt-get -y install python3-pip
+
+# ffmpeg was missing
+RUN apt-get -y install ffmpeg
+
 # Install Git
-RUN apt install git
+RUN apt -y install git
 
 # Install Facebook Demucs
 RUN mkdir -p /lib/demucs
@@ -14,8 +25,19 @@ WORKDIR /lib/demucs
 RUN git clone -b main --single-branch https://github.com/facebookresearch/demucs /lib/demucs
 
 RUN python3 -m pip install -e .
-RUN python3 -m demucs.separate -d cpu test.mp3 # Trigger model download
-RUN rm -r separated  # cleanup
+
+# torch 10.2 was installed by default probably from other dependencies; force remove it
+RUN python3 -m pip uninstall torch torchvision torchaudio -y
+
+# install torch 11.6
+RUN python3 -m pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
+
+# Trigger model download
+# TODO: parameterize model selection here?
+RUN python3 -m demucs.separate test.mp3
+
+# cleanup
+RUN rm -r separated
 
 VOLUME /data/input
 VOLUME /data/output

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,17 @@ help: ## Display available targets
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf " \033[36m%-20s\033[0m  %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY:
+## TODO: parameterize the model to dynamically pass -n mdx / mdx_extra
 run: ## Run the demucs spliting the tracks placed in the input folder
 	docker run --rm -i \
 		--name=demucs \
 		-v $(current-dir)input:/data/input \
 		-v $(current-dir)output:/data/output \
 		-v $(current-dir)models:/data/models \
-		xserrat/facebook-demucs:latest \
+		--gpus all \
+		gpu-test:11-8 \
 		"python3 -m demucs.separate --out /data/output \
 		/data/input/$(track)"
 .PHONY:
 build: ## Build docker image with all needed to run the facebook demucs ML code
-	docker build --no-cache -t xserrat/facebook-demucs:latest .
+	docker build --no-cache -t gpu-test:11-8 .


### PR DESCRIPTION
First pass at passing the hosts GPU to the container. 
- Sort out image tagging, right now it's just making an arbitrary image locally
- Consider adding a param to specify which model to use
- Consider specifying which GPU to pass, if multiple are present?
- Improve pytorch versioning so we don't have to delete it and reinstall it

Other things we might as well fix:
- Quotes in the file name don't seem to be applied when passing into the `docker run` command
- Makefile is in home directory, but inputs are in `/inputs`, so you might want to provide: `make run track=input/myfile.mp3` but that actually passes `data/input/input/myfile.mp3`


Tested with RTX 3080, splits 4 segments in about 10 seconds.
re #21