### PR TITLE
Dockerfile updates for more reliable build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone Demucs (now maintained in the original author's github space)
-RUN git clone -b main --single-branch https://github.com/adefossez/demucs /lib/demucs
+RUN git clone --single-branch --branch main https://github.com/adefossez/demucs /lib/demucs
 WORKDIR /lib/demucs
 # Checkout known stable commit on main
 RUN git checkout b9ab48cad45976ba42b2ff17b229c071f0df9390

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image supports Nvidia CUDA but does not require it and can also run demucs on the CPU
-FROM nvidia/cuda:11.8.0-base-ubuntu22.04
+FROM nvidia/cuda:12.6.2-base-ubuntu22.04
 
 USER root
 ENV TORCH_HOME=/data/models
@@ -18,12 +18,14 @@ RUN apt update && apt install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone Facebook Demucs
-RUN git clone --depth 1 --branch v4.0.0 --single-branch https://github.com/facebookresearch/demucs /lib/demucs
+# Clone Demucs (now maintained in the original author's github space)
+RUN git clone -b main --single-branch https://github.com/adefossez/demucs /lib/demucs
 WORKDIR /lib/demucs
+# Checkout known stable commit on main
+RUN git checkout b9ab48cad45976ba42b2ff17b229c071f0df9390
 
-# Install dependencies
-RUN python3 -m pip install -e . --no-cache-dir
+# Install dependencies with overrides for known working versions on this base image
+RUN python3 -m pip install -e . "torch<2" "torchaudio<2" "numpy<2" --no-cache-dir
 # Run once to ensure demucs works and trigger the default model download
 RUN python3 -m demucs -d cpu test.mp3 
 # Cleanup output - we just used this to download the model


### PR DESCRIPTION
Just some minor updates - came back to this recently and the image build wasn't working anymore. Can't quite get things to work with the latest torch dependencies, so focused on a more reliable build for now.

* Update to latest Nvidia CUDA base image.
* Clone demucs from its new maintained location since the original author left Facebook/Meta.
* Checkout a known working commit for demucs.
* Override key dependencies that work together for this particular base image and demucs commit.