### PR TITLE
Support missing demucs options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,21 +26,21 @@ endif
 
 # Construct commands
 docker-run-command = docker run --rm -i \
-						--name=demucs \
-						$(docker-gpu-option) \
-						-v $(current-dir)input:/data/input \
-						-v $(current-dir)output:/data/output \
-						-v $(current-dir)models:/data/models \
-						xserrat/facebook-demucs:latest
+	--name=demucs \
+	$(docker-gpu-option) \
+	-v $(current-dir)input:/data/input \
+	-v $(current-dir)output:/data/output \
+	-v $(current-dir)models:/data/models \
+	xserrat/facebook-demucs:latest
 
 demucs-command = "python3 -m demucs -n $(model) \
-					--out /data/output \
-					$(demucs-mp3-option) \
-					$(demucs-twostems-option) \
-					--shifts $(shifts) \
-					--overlap $(overlap) \
-					-j $(jobs) \
-					\"/data/input/$(track)\""
+	--out /data/output \
+	$(demucs-mp3-option) \
+	$(demucs-twostems-option) \
+	--shifts $(shifts) \
+	--overlap $(overlap) \
+	-j $(jobs) \
+	\"/data/input/$(track)\""
 
 .PHONY:
 .SILENT:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Option | Default Value | Description
 `gpu`           | `false` | Enable Nvidia CUDA support (requires an Nvidia GPU).
 `model`         | `demucs`| The model used for audio separation. See https://github.com/facebookresearch/demucs#separating-tracks for a list of available models to use.
 `mp3output`     | `false` | Output separated audio in `mp3` format instead of the default `wav` format.
-`shifts`        | `1`     | Performs multiple predictions with random shifts (a.k.a the shift trick) of the input and average them. This makes prediction `SHIFTS` times slower. Don't use it unless you have a GPU.
+`shifts`        | `1`     | Perform multiple predictions with random shifts (a.k.a the shift trick) of the input and average them. This makes prediction `SHIFTS` times slower. Don't use it unless you have a GPU.
 `overlap`       | `0.25`  | Controls the amount of overlap between prediction windows. Default is 0.25 (i.e. 25%) which is probably fine. It can probably be reduced to 0.1 to improve separation speed.
-`jobs`          | `1`     | Specifies the number of parallel jobs to run during separation. This will multiply the amount the RAM used by the same number, so be careful!
+`jobs`          | `1`     | Specifies the number of parallel jobs to run during separation. This will multiply the amount of RAM used by the same number, so be careful!
 `splittrack`    |         | Individual track to split/separate from the others (e.g., you only want to separate drums). Valid options are `bass`, `drums`, `vocals` and `other`. Other values may be allowed if the model can separate additional track types.
 
 Example commands:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Option | Default Value | Description
 `model`         | `demucs`| The model used for audio separation. See https://github.com/facebookresearch/demucs#separating-tracks for a list of available models to use.
 `mp3output`     | `false` | Output separated audio in `mp3` format instead of the default `wav` format.
 `shifts`        | `1`     | Perform multiple predictions with random shifts (a.k.a the shift trick) of the input and average them. This makes prediction `SHIFTS` times slower. Don't use it unless you have a GPU.
-`overlap`       | `0.25`  | Controls the amount of overlap between prediction windows. Default is 0.25 (i.e. 25%) which is probably fine. It can probably be reduced to 0.1 to improve separation speed.
-`jobs`          | `1`     | Specifies the number of parallel jobs to run during separation. This will multiply the amount of RAM used by the same number, so be careful!
+`overlap`       | `0.25`  | Control the amount of overlap between prediction windows. Default is 0.25 (i.e. 25%) which is probably fine. It can probably be reduced to 0.1 to improve separation speed.
+`jobs`          | `1`     | Specify the number of parallel jobs to run during separation. This will multiply the amount of RAM used by the same number, so be careful!
 `splittrack`    |         | Individual track to split/separate from the others (e.g., you only want to separate drums). Valid options are `bass`, `drums`, `vocals` and `other`. Other values may be allowed if the model can separate additional track types.
 
 Example commands:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Option | Default Value | Description
 `gpu`           | `false` | Enable Nvidia CUDA support (requires an Nvidia GPU).
 `model`         | `demucs`| The model used for audio separation. See https://github.com/facebookresearch/demucs#separating-tracks for a list of available models to use.
 `mp3output`     | `false` | Output separated audio in `mp3` format instead of the default `wav` format.
+`shifts`        | `1`     | Performs multiple predictions with random shifts (a.k.a the shift trick) of the input and average them. This makes prediction `SHIFTS` times slower. Don't use it unless you have a GPU.
+`overlap`       | `0.25`  | Controls the amount of overlap between prediction windows. Default is 0.25 (i.e. 25%) which is probably fine. It can probably be reduced to 0.1 to improve separation speed.
+`jobs`          | `1`     | Specifies the number of parallel jobs to run during separation. This will multiply the amount the RAM used by the same number, so be careful!
 `splittrack`    |         | Individual track to split/separate from the others (e.g., you only want to separate drums). Valid options are `bass`, `drums`, `vocals` and `other`. Other values may be allowed if the model can separate additional track types.
 
 Example commands:


### PR DESCRIPTION
Addresses #34 and adds the rest of the documented demucs options.

Also made a tweak so the demucs command being run in the container is echoed out - a sanity check on "what exactly is executing?".